### PR TITLE
support json value of null

### DIFF
--- a/src/components/JsonToTable/JsonToTableUtils.ts
+++ b/src/components/JsonToTable/JsonToTableUtils.ts
@@ -15,7 +15,7 @@ export default class JsonToTableUtils {
      * Get object type
      */
     public static getObjectType(obj: any): JSONObjectType {
-        if (typeof obj === "object") {
+        if (obj !== null && typeof obj === "object") {
             if (Array.isArray(obj)) {
                 return JSONObjectType.Array;
             } else {


### PR DESCRIPTION
```javascript
typeof null === 'object'
```
So if some value is `null` in JSON, an error will be thrown because of 
```javascript
Object.keys(null)
```
is illegal.