### PR TITLE
Fixed: Objects are not valid as a React child error for complex JSON …

### DIFF
--- a/src/components/JsonToTable/JsonToTable.tsx
+++ b/src/components/JsonToTable/JsonToTable.tsx
@@ -107,7 +107,7 @@ export default class JsonToTable extends React.Component<IJsonToTableProps,
                 <tr key={`__j2t_Arr${idx.toString()}`}>
                     {labels.map(k => {
                         const isValuePrimitive =
-                            JSONToTableUtils.getObjectType(k) === JSONObjectType.Primitive;
+                            JSONToTableUtils.getObjectType(item[k]) === JSONObjectType.Primitive;
                         return isValuePrimitive
                             ? this.renderCell({content: item[k]})
                             : this.renderObject(item[k], k, idx);


### PR DESCRIPTION
isValuePrimitive check was being done for the key but not for the value of the object